### PR TITLE
✨ Add padding to the main page components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,10 +10,10 @@ export default function Home() {
         <h1 className="text-primary font-bold text-2xl sm:text-2xl md:text-3xl lg:text-4xl">
           Verifiable insights into the maturity and risks of DeFi
         </h1>
-        <div className="flex flex-col w-full my-2 lg:flex-row">
+        <div className="flex flex-col w-full my-2 lg:flex-row gap-2">
           <Chart className="w-full border border-secondary lg:w-2/3" />
 
-          <div className="flex flex-col w-full lg:w-1/3 mt-4 lg:mt-0">
+          <div className="flex flex-col w-full lg:w-1/3 mt-4 lg:mt-0 gap-2 *:gap-2">
             <div className="flex flex-row lg:w-full">
               <PieChartComponent
                 groupByKey="stage"


### PR DESCRIPTION
Quick PR to add some padding to the components of the main page.
It's just a suggestion, non-spaced components look a bit weird from my point of view.

Before:

<img width="1108" alt="Capture d’écran 2025-03-08 à 15 07 01" src="https://github.com/user-attachments/assets/3e8f10b1-36fa-4ef8-867b-eb4e491e6915" />

After:

<img width="1121" alt="Capture d’écran 2025-03-08 à 15 07 16" src="https://github.com/user-attachments/assets/1c5791bb-9bf1-4aba-aa75-4ed7014825cc" />
