### PR TITLE
Fix: enforce protocol ID names at compilation time

### DIFF
--- a/velite.config.ts
+++ b/velite.config.ts
@@ -36,6 +36,17 @@ const protocols = defineCollection({
       x: s.string()
     }),
     github: s.array(s.string().url())
+  }).transform((data, context) => {
+    // Extract folder name from the file path
+    const filePath = context.meta.path;
+    const folderName = filePath.split('/').slice(-2, -1)[0]; // Get folder name from path like "protocols/uniswap-v3/data.json"
+    
+    // Check if id matches folder name
+    if (data.id !== folderName) {
+      throw new Error(`Protocol ID "${data.id}" does not match folder name "${folderName}" in ${filePath}`);
+    }
+    
+    return data;
   })
 })
 


### PR DESCRIPTION
This change enforces that the protocols' id names in data.json is the same as their respective folder. This solves the issue of it being a completely silent error for now, hard to detect.