### PR TITLE
Remove Uniswap instances with unverified contracta from "Others"

### DIFF
--- a/src/content/protocols/uniswap-v3/arbitrum.md
+++ b/src/content/protocols/uniswap-v3/arbitrum.md
@@ -107,7 +107,7 @@ Despite this classification, our analysis shows that the Uniswap V3 deployment o
 
 # Reviewer Notes
 
-⚠️ During our analysis, we identified three unverified contracts, [NFTDescriptor](https://arbiscan.io/address/0x42B24A95702b9986e82d421cC3568932790A48Ec#code), [NonfungibleTokenPositionDescriptor](https://arbiscan.io/address/0x91ae842A5Ffd8d12023116943e72A606179294f3#code) and [Multicall](https://arbiscan.io/address/0xadF885960B47eA2CD9B55E6DAc6B42b7Cb2806dB#code), on Arbitrum. While these contracts remain unverified, if they match the deployed code on Ethereum mainnet, we can confirm the upgradability risk remains low. We strongly recommend that Uniswap verifies these contracts to ensure transparency and alignment with their security standards.
+⚠️ During our analysis, we identified three unverified contracts, [NFTDescriptor](https://arbiscan.io/address/0x42B24A95702b9986e82d421cC3568932790A48Ec#code), [NonfungibleTokenPositionDescriptor](https://arbiscan.io/address/0x91ae842A5Ffd8d12023116943e72A606179294f3#code) and [Multicall](https://arbiscan.io/address/0xadF885960B47eA2CD9B55E6DAc6B42b7Cb2806dB#code), on Arbitrum. While these contracts remain unverified, if they match the deployed code on Ethereum mainnet, we can confirm the upgradability risk remains low. We strongly recommend that Uniswap verifies these contracts to ensure transparency and alignment with their security standards. Since those contracts are non-essential to the functioning of the protocol, this does not impact the score.
 
 # Protocol Analysis
 

--- a/src/content/protocols/uniswap-v3/arbitrum.md
+++ b/src/content/protocols/uniswap-v3/arbitrum.md
@@ -9,7 +9,7 @@ github:
   ]
 defillama_slug: ["uniswap-v3"]
 chain: "Arbitrum"
-stage: "O"
+stage: 2
 reasons: ["Unverified Contracts"]
 risks: ["M", "L", "L", "L", "L"]
 author: ["mmilien", "CookingCryptos"]
@@ -19,20 +19,34 @@ update_date: "2025-01-31"
 stage_requirements:
   [
     [
-      { text: "Assets are not in custody by a centralized entity", status: "unfixed" },
-      { text: "Source-available codebase", status: "unfixed" },
-      { text: "Public documentation exists", status: "unfixed" },
+      {
+        text: "Assets are not in custody by a centralized entity",
+        status: "fixed",
+      },
+      { text: "Source-available codebase", status: "fixed" },
+      { text: "Public documentation exists", status: "fixed" },
     ],
     [
-      { text: "Upgrades have no potential of “loss of funds“ ", status: "fixed"},
-      { text: "Dependency with a High centralization score is mitigated", status: "fixed" },
-      { text: "Frontend backups or self-hosting option exists", status: "fixed"},
+      {
+        text: "Upgrades have no potential of “loss of funds“ ",
+        status: "fixed",
+      },
+      {
+        text: "Dependency with a High centralization score is mitigated",
+        status: "fixed",
+      },
+      {
+        text: "Frontend backups or self-hosting option exists",
+        status: "fixed",
+      },
     ],
     [
-      
-      { text: "Upgrades have no potential of “loss of funds or unclaimed yield“", status: "fixed" },
+      {
+        text: "Upgrades have no potential of “loss of funds or unclaimed yield“",
+        status: "fixed",
+      },
       { text: "There are no external dependencies", status: "fixed" },
-      { text: "Alternative third-party frontends exist", status: "fixed" }  
+      { text: "Alternative third-party frontends exist", status: "fixed" },
     ],
   ]
 ---

--- a/src/content/protocols/uniswap-v3/base.md
+++ b/src/content/protocols/uniswap-v3/base.md
@@ -9,7 +9,7 @@ github:
   ]
 defillama_slug: ["uniswap-v3"]
 chain: "Base"
-stage: "O"
+stage: 2
 reasons: ["Unverified Contracts"]
 risks: ["H", "L", "L", "L", "L"]
 author: ["mmilien", "CookingCryptos"]
@@ -19,19 +19,34 @@ update_date: "2025-01-31"
 stage_requirements:
   [
     [
-      { text: "Assets are not in custody by a centralized entity", status: "unfixed" },
-      { text: "Source-available codebase", status: "unfixed" },
-      { text: "Public documentation exists", status: "unfixed" },
+      {
+        text: "Assets are not in custody by a centralized entity",
+        status: "fixed",
+      },
+      { text: "Source-available codebase", status: "fixed" },
+      { text: "Public documentation exists", status: "fixed" },
     ],
     [
-      { text: "Upgrades have no potential of “loss of funds“ ", status: "fixed"},
-      { text: "Dependency with a High centralization score is mitigated", status: "fixed" },
-      { text: "Frontend backups or self-hosting option exists", status: "fixed"},
+      {
+        text: "Upgrades have no potential of “loss of funds“ ",
+        status: "fixed",
+      },
+      {
+        text: "Dependency with a High centralization score is mitigated",
+        status: "fixed",
+      },
+      {
+        text: "Frontend backups or self-hosting option exists",
+        status: "fixed",
+      },
     ],
     [
-      { text: "Upgrades have no potential of “loss of funds or unclaimed yield“", status: "fixed" },
+      {
+        text: "Upgrades have no potential of “loss of funds or unclaimed yield“",
+        status: "fixed",
+      },
       { text: "There are no external dependencies", status: "fixed" },
-      { text: "Alternative third-party frontends exist", status: "fixed" }  
+      { text: "Alternative third-party frontends exist", status: "fixed" },
     ],
   ]
 ---

--- a/src/content/protocols/uniswap-v3/base.md
+++ b/src/content/protocols/uniswap-v3/base.md
@@ -107,7 +107,7 @@ Despite this classification, our analysis shows that the Uniswap V3 deployment o
 
 # Reviewer notes
 
-⚠️ During our analysis, we identified two unverified contracts, [ProxyAdmin](https://basescan.org/address/0x3334d83e224aF5ef9C2E7DDA7c7C98Efd9621fA9#code) and [TransparentUpgradeableProxy](https://basescan.org/address/0x4615C383F85D0a2BbED973d83ccecf5CB7121463#code), on Base. While these contracts remain unverified, if they match the deployed code on Ethereum mainnet, we can confirm the upgradability risk remains low. We strongly recommend that Uniswap verifies these contracts to ensure transparency and alignment with their security standards.
+⚠️ During our analysis, we identified two unverified contracts, [ProxyAdmin](https://basescan.org/address/0x3334d83e224aF5ef9C2E7DDA7c7C98Efd9621fA9#code) and [TransparentUpgradeableProxy](https://basescan.org/address/0x4615C383F85D0a2BbED973d83ccecf5CB7121463#code), on Base. While these contracts remain unverified, if they match the deployed code on Ethereum mainnet, we can confirm the upgradability risk remains low. We strongly recommend that Uniswap verifies these contracts to ensure transparency and alignment with their security standards. Since those contracts are non-essential to the functioning of the protocol, this does not impact the score.
 
 # Protocol Analysis
 


### PR DESCRIPTION
Given the recent change of the framework, if contracts that are non-essential and non-critical to the protocol are not verified, they do not impact its score.